### PR TITLE
Update package name to use all-lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "slim/flash": "^0.1.0",
         "monolog/monolog": "^1.13",
         "vlucas/phpdotenv": "^2.4",
-        "catfan/Medoo": "^1.1",
+        "catfan/medoo": "^1.1",
         "hiropeke/slim-blade-view": "^0.1.1",
         "slim/csrf": "^0.7.0",
         "ozdemir/datatables": "^1.5",


### PR DESCRIPTION
Composer 2.0 will deprecate required all packages to use lowercase name.